### PR TITLE
Add a macro on Jolla SailfishOS to fix nullptr crash when the message field is undefined

### DIFF
--- a/priv/quickfluxfunctions.h
+++ b/priv/quickfluxfunctions.h
@@ -9,7 +9,7 @@ namespace QuickFlux {
 
 }
 
-#if (QT_VERSION == QT_VERSION_CHECK(5,7,1)) || (QT_VERSION == QT_VERSION_CHECK(5,8,0))
+#if (QT_VERSION == QT_VERSION_CHECK(5,7,1)) || (QT_VERSION == QT_VERSION_CHECK(5,8,0) || defined(SAILFISH_OS))
 
 /* A dirty hack to fix QTBUG-58133 and #13 issue.
 


### PR DESCRIPTION
I use quickflux to build app on Jolla SailfishOS, and found this fix should be added too. 
Just a SAILFISH_OS marco
See
https://github.com/benlau/quickflux/commit/6526be915cfdc4b6cf6c6787f6b53241597a74dd 