### PR TITLE
fix vs2013+qt5.6.2 build error

### DIFF
--- a/examples/photoalbum/actions/AppActions.qml
+++ b/examples/photoalbum/actions/AppActions.qml
@@ -34,7 +34,7 @@ ActionCreator {
     }
 
     function navigateBack() {
-        AppDispatcher.dispatch(ActionTypes.navigateBack, {});
+        AppDispatcher.dispatch(ActionTypes.navigateBack);
     }
 }
 

--- a/examples/photoalbum/actions/AppActions.qml
+++ b/examples/photoalbum/actions/AppActions.qml
@@ -34,7 +34,7 @@ ActionCreator {
     }
 
     function navigateBack() {
-        AppDispatcher.dispatch(ActionTypes.navigateBack);
+        AppDispatcher.dispatch(ActionTypes.navigateBack, {});
     }
 }
 

--- a/qfhydrate.cpp
+++ b/qfhydrate.cpp
@@ -3,10 +3,11 @@
 #include "qfhydrate.h"
 #include "qfobject.h"
 #include "qfstore.h"
+#include <functional>
 
 static QVariantMap dehydrator(QObject* source);
 
-static auto dehydratorFunction = [](const QStringList& ignoreList) {
+static auto dehydratorFunction = [](const QStringList& ignoreList) -> std::function<QVariantMap (QObject *)> {
 
     return [=](QObject* source) {
         QVariantMap dest;


### PR DESCRIPTION
fix bug photoalbum demo click comfirm crash
fix vs2013+qt5.6.2 build error

..\..\qfhydrate.cpp(11) : error C2440: “return”: 无法从“<lambda_1b5b698c2abb3ad041546665e0ea6089>::()::<lambda_da8af93d7dfaf560314855c43192cef6>”转换为“QVariantMap (__cdecl *)(QObject *)”
        没有可用于执行该转换的用户定义的转换运算符，或者无法调用该运算符
..\..\qfhydrate.cpp(11) : error C2440: “return”: 无法从“<lambda_1b5b698c2abb3ad041546665e0ea6089>::<helper_func_cdecl>::<lambda_b8018bedf0be01f6932204ff2ff67464>”转换为“QVariantMap (__cdecl *)(QObject *)”
        没有可用于执行该转换的用户定义的转换运算符，或者无法调用该运算符
..\..\qfhydrate.cpp(11) : error C2440: “return”: 无法从“<lambda_1b5b698c2abb3ad041546665e0ea6089>::<helper_func_stdcall>::<lambda_487927dd8422d7d3fd9ebc5412740621>”转换为“QVariantMap (__cdecl *)(QObject *)”
        没有可用于执行该转换的用户定义的转换运算符，或者无法调用该运算符
..\..\qfhydrate.cpp(11) : error C2440: “return”: 无法从“<lambda_1b5b698c2abb3ad041546665e0ea6089>::<helper_func_fastcall>::<lambda_c4bce5fa525ad793e5c622a263b6db92>”转换为“QVariantMap (__cdecl *)(QObject *)”
        没有可用于执行该转换的用户定义的转换运算符，或者无法调用该运算符
..\..\qfhydrate.cpp(11) : error C2440: “return”: 无法从“<lambda_1b5b698c2abb3ad041546665e0ea6089>::<helper_func_vectorcall>::<lambda_180428f91722cd3f24ccd928d90db9c4>”转换为“QVariantMap (__cdecl *)(QObject *)”
        没有可用于执行该转换的用户定义的转换运算符，或者无法调用该运算符