### PR TITLE
Fixed CMake build file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,72 +8,103 @@ project(quickflux)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_DEBUG_POSTFIX d)
+
+set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Quick REQUIRED)
 find_package(Qt5Qml REQUIRED)
 find_package(Qt5Gui REQUIRED)
 
-include_directories(${Qt5Qml_INCLUDE_DIRS})
+include_directories(
+	${SRC_DIR}
+	${Qt5Qml_INCLUDE_DIRS}
+)
 
 add_definitions(${Qt5Qml_DEFINITIONS})
 add_definitions(${Qt5Quick_DEFINITIONS})
 
 #Include headers from priv folder as CMAKE_AUTOMOC do not works on it
 qt5_wrap_cpp(moc 
-    priv/qflistener.h
-    priv/qfappscriptrunnable.h
-    priv/qfappscriptdispatcherwrapper.h
+    ${SRC_DIR}/priv/qflistener.h
+    ${SRC_DIR}/priv/qfappscriptrunnable.h
+    ${SRC_DIR}/priv/qfappscriptdispatcherwrapper.h
 )
 
-set(SOURCES
-    qfapplistener.cpp
-    qfappdispatcher.cpp
-    qfappscript.cpp
-    qfappscriptrunnable.cpp
-    qfappscriptdispatcherwrapper.cpp
-    qflistener.cpp
-    qfqmltypes.cpp
-    qfapplistenergroup.cpp
-    qfappscriptgroup.cpp
-    qffilter.cpp
-    qfkeytable.cpp
-    priv/qfsignalproxy.cpp
-    qfactioncreator.cpp
-    qfmiddleware.cpp
-    qfmiddlewarelist.cpp
-    qfobject.cpp
-    qfstore.cpp
-    qfdispatcher.cpp
-    priv/qfmiddlewareshook.cpp
-    priv/qfhook.cpp
-    priv/quickfluxfunctions.cpp
-    qfhydrate.cpp
+set(quickflux_SOURCES
+    ${SRC_DIR}/qfapplistener.cpp
+    ${SRC_DIR}/qfappdispatcher.cpp
+    ${SRC_DIR}/qfappscript.cpp
+    ${SRC_DIR}/qfappscriptrunnable.cpp
+    ${SRC_DIR}/qfappscriptdispatcherwrapper.cpp
+    ${SRC_DIR}/qflistener.cpp
+    ${SRC_DIR}/qfqmltypes.cpp
+    ${SRC_DIR}/qfapplistenergroup.cpp
+    ${SRC_DIR}/qfappscriptgroup.cpp
+    ${SRC_DIR}/qffilter.cpp
+    ${SRC_DIR}/qfkeytable.cpp
+    ${SRC_DIR}/priv/qfsignalproxy.cpp
+    ${SRC_DIR}/qfactioncreator.cpp
+    ${SRC_DIR}/qfmiddleware.cpp
+    ${SRC_DIR}/qfmiddlewarelist.cpp
+    ${SRC_DIR}/qfobject.cpp
+    ${SRC_DIR}/qfstore.cpp
+    ${SRC_DIR}/qfdispatcher.cpp
+    ${SRC_DIR}/priv/qfmiddlewareshook.cpp
+    ${SRC_DIR}/priv/qfhook.cpp
+    ${SRC_DIR}/priv/quickfluxfunctions.cpp
+    ${SRC_DIR}/qfhydrate.cpp
 )
 
-set(HEADERS
-    qfappdispatcher.h
-    qfapplistener.h
-    qfappscript.h
-    priv/qfappscriptrunnable.h
-    priv/qfappscriptdispatcherwrapper.h
-    priv/qflistener.h
-    qfapplistenergroup.h
-    qfappscriptgroup.h
-    qffilter.h
-    qfkeytable.h
-    priv/qfsignalproxy.h
-    qfactioncreator.h
-    qfmiddleware.h
-    qfmiddlewarelist.h
-    qfdispatcher.h
-    QFAppDispatcher
-    QFKeyTable
-    QuickFlux
+set(quickflux_PRIVATE_HEADERS
+    ${SRC_DIR}/priv/qfappscriptrunnable.h
+    ${SRC_DIR}/priv/qfappscriptdispatcherwrapper.h
+    ${SRC_DIR}/priv/qflistener.h
+    ${SRC_DIR}/priv/qfsignalproxy.h
 )
 
+set(quickflux_PUBLIC_HEADERS
+    ${SRC_DIR}/qfappdispatcher.h
+    ${SRC_DIR}/qfapplistener.h
+    ${SRC_DIR}/qfappscript.h
+    ${SRC_DIR}/qfapplistenergroup.h
+    ${SRC_DIR}/qfappscriptgroup.h
+    ${SRC_DIR}/qffilter.h
+    ${SRC_DIR}/qfkeytable.h
+    ${SRC_DIR}/qfactioncreator.h
+    ${SRC_DIR}/qfmiddleware.h
+    ${SRC_DIR}/qfmiddlewarelist.h
+    ${SRC_DIR}/qfdispatcher.h
+    ${SRC_DIR}/QFAppDispatcher
+    ${SRC_DIR}/QFKeyTable
+    ${SRC_DIR}/QuickFlux
+)
 
-add_library(quickflux STATIC ${SOURCES} ${moc})
+add_library(quickflux STATIC
+	${quickflux_SOURCES}
+	${quickflux_PRIVATE_HEADERS}
+	${quickflux_PUBLIC_HEADERS}
+	${moc}
+)
+target_link_libraries(quickflux
+	Qt5::Qml
+	Qt5::Quick
+	Qt5::Core
+)
 
-target_link_libraries(quickflux Qt5::Qml Qt5::Quick Qt5::Core)
 target_include_directories(quickflux PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+install(TARGETS quickflux
+	DESTINATION lib
+)
+
+install(FILES
+	${quickflux_PUBLIC_HEADERS}
+	DESTINATION includes
+)
+
+install(FILES
+	${quickflux_PRIVATE_HEADERS}
+	DESTINATION includes/priv
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(quickflux)
 
+if(MSVC)
+	set_property (GLOBAL PROPERTY USE_FOLDERS ON)
+endif()
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_DEBUG_POSTFIX d)
@@ -89,6 +93,14 @@ set(quickflux_PUBLIC_HEADERS
 	${SRC_DIR}/qfstore.h
     ${SRC_DIR}/QuickFlux
 )
+
+if(MSVC)
+	source_group("Source Files" FILES ${quickflux_PUBLIC_SOURCES})
+	source_group("Source Files\\Private" FILES ${quickflux_PRIVATE_SOURCES})
+	source_group("Header Files" FILES ${quickflux_PUBLIC_HEADERS})
+	source_group("Header Files\\Private" FILES ${quickflux_PRIVATE_HEADERS})
+	source_group("Source Files\\MOC" REGULAR_EXPRESSION "moc*")
+endif()
 
 add_library(quickflux STATIC
 	${quickflux_PRIVATE_SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,64 +25,74 @@ include_directories(
 add_definitions(${Qt5Qml_DEFINITIONS})
 add_definitions(${Qt5Quick_DEFINITIONS})
 
-#Include headers from priv folder as CMAKE_AUTOMOC do not works on it
+# Include headers from priv folder as CMAKE_AUTOMOC do not works on it
 qt5_wrap_cpp(moc 
     ${SRC_DIR}/priv/qflistener.h
     ${SRC_DIR}/priv/qfappscriptrunnable.h
     ${SRC_DIR}/priv/qfappscriptdispatcherwrapper.h
 )
 
-set(quickflux_SOURCES
-    ${SRC_DIR}/qfapplistener.cpp
-    ${SRC_DIR}/qfappdispatcher.cpp
-    ${SRC_DIR}/qfappscript.cpp
-    ${SRC_DIR}/qfappscriptrunnable.cpp
-    ${SRC_DIR}/qfappscriptdispatcherwrapper.cpp
-    ${SRC_DIR}/qflistener.cpp
-    ${SRC_DIR}/qfqmltypes.cpp
-    ${SRC_DIR}/qfapplistenergroup.cpp
-    ${SRC_DIR}/qfappscriptgroup.cpp
-    ${SRC_DIR}/qffilter.cpp
-    ${SRC_DIR}/qfkeytable.cpp
+set(quickflux_PRIVATE_SOURCES
+    ${SRC_DIR}/priv/qfhook.cpp
+    ${SRC_DIR}/priv/qfmiddlewareshook.cpp
     ${SRC_DIR}/priv/qfsignalproxy.cpp
+    ${SRC_DIR}/priv/quickfluxfunctions.cpp
+)
+
+set(quickflux_PUBLIC_SOURCES
     ${SRC_DIR}/qfactioncreator.cpp
+    ${SRC_DIR}/qfappdispatcher.cpp
+    ${SRC_DIR}/qfapplistener.cpp
+    ${SRC_DIR}/qfapplistenergroup.cpp
+    ${SRC_DIR}/qfappscript.cpp
+    ${SRC_DIR}/qfappscriptdispatcherwrapper.cpp
+    ${SRC_DIR}/qfappscriptgroup.cpp
+    ${SRC_DIR}/qfappscriptrunnable.cpp
+    ${SRC_DIR}/qfdispatcher.cpp
+    ${SRC_DIR}/qffilter.cpp
+    ${SRC_DIR}/qfhydrate.cpp
+    ${SRC_DIR}/qfkeytable.cpp
+    ${SRC_DIR}/qflistener.cpp
     ${SRC_DIR}/qfmiddleware.cpp
     ${SRC_DIR}/qfmiddlewarelist.cpp
     ${SRC_DIR}/qfobject.cpp
+    ${SRC_DIR}/qfqmltypes.cpp
     ${SRC_DIR}/qfstore.cpp
-    ${SRC_DIR}/qfdispatcher.cpp
-    ${SRC_DIR}/priv/qfmiddlewareshook.cpp
-    ${SRC_DIR}/priv/qfhook.cpp
-    ${SRC_DIR}/priv/quickfluxfunctions.cpp
-    ${SRC_DIR}/qfhydrate.cpp
 )
 
 set(quickflux_PRIVATE_HEADERS
-    ${SRC_DIR}/priv/qfappscriptrunnable.h
     ${SRC_DIR}/priv/qfappscriptdispatcherwrapper.h
+    ${SRC_DIR}/priv/qfappscriptrunnable.h
+	${SRC_DIR}/priv/qfhook.h
     ${SRC_DIR}/priv/qflistener.h
+	${SRC_DIR}/priv/qfmiddlewareshook.h
     ${SRC_DIR}/priv/qfsignalproxy.h
+	${SRC_DIR}/priv/quickfluxfunctions.h
 )
 
 set(quickflux_PUBLIC_HEADERS
-    ${SRC_DIR}/qfappdispatcher.h
-    ${SRC_DIR}/qfapplistener.h
-    ${SRC_DIR}/qfappscript.h
-    ${SRC_DIR}/qfapplistenergroup.h
-    ${SRC_DIR}/qfappscriptgroup.h
-    ${SRC_DIR}/qffilter.h
-    ${SRC_DIR}/qfkeytable.h
     ${SRC_DIR}/qfactioncreator.h
+    ${SRC_DIR}/QFAppDispatcher
+    ${SRC_DIR}/qfapplistener.h
+    ${SRC_DIR}/qfapplistenergroup.h
+    ${SRC_DIR}/qfappscript.h
+    ${SRC_DIR}/qfappdispatcher.h
+    ${SRC_DIR}/qfappscriptgroup.h
+    ${SRC_DIR}/qfdispatcher.h
+    ${SRC_DIR}/qffilter.h
+    ${SRC_DIR}/qfhydrate.h
+    ${SRC_DIR}/QFKeyTable
+    ${SRC_DIR}/qfkeytable.h
     ${SRC_DIR}/qfmiddleware.h
     ${SRC_DIR}/qfmiddlewarelist.h
-    ${SRC_DIR}/qfdispatcher.h
-    ${SRC_DIR}/QFAppDispatcher
-    ${SRC_DIR}/QFKeyTable
+	${SRC_DIR}/qfobject.h
+	${SRC_DIR}/qfstore.h
     ${SRC_DIR}/QuickFlux
 )
 
 add_library(quickflux STATIC
-	${quickflux_SOURCES}
+	${quickflux_PRIVATE_SOURCES}
+	${quickflux_PUBLIC_SOURCES}
 	${quickflux_PRIVATE_HEADERS}
 	${quickflux_PUBLIC_HEADERS}
 	${moc}

--- a/README.md
+++ b/README.md
@@ -87,6 +87,33 @@ Installation Instruction (without qpm)
 import QuickFlux 1.0
 ```
 
+Installation Instruction (with CMake)
+=====================================
+
+Add QuickFlux as an external project in your CMakeLists.txt:
+ 
+```
+include(ExternalProject)
+
+ExternalProject_Add(QuickFlux
+	PREFIX "${PROJECT_BINARY_DIR}/QuickFlux-build"
+	GIT_REPOSITORY "https://github.com/benlau/quickflux.git"
+	CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/QuickFlux"
+)
+
+link_directories("${PROJECT_BINARY_DIR}/QuickFlux/lib")
+include_directories("${PROJECT_BINARY_DIR}/QuickFlux/includes")
+
+...
+
+add_dependencies(<your target> QuickFlux)
+target_link_libraries(<your target>	debug quickfluxd optimized quickflux)
+```
+
+Instead of using GIT_REPOSITORY which clones a remote repository, you can use SOURCE_DIR with a local path which contains the project sources.
+
+You may need to add ```"-DCMAKE_PREFIX_PATH=<your Qt install path>"``` to the CMAKE_ARGS on some platforms.
+
 Example Projects
 ================
 


### PR DESCRIPTION
In commit 53028a6 the source and header files were moved into a subdirectory, which ultimately broke the CMake build. Additionally, the CMakeLists.txt did not contain any install directives, making it quite hard to use as an external project from another CMake-based Qt project.

I've reworked the CMakeLists.txt so it can be either built standalone or as an external project, and added a usage example to the README.md file.