### PR TITLE
Create a quickflux_INSTALL option 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(quickflux VERSION 1.1.3)
 
+option(quickflux_INSTALL "Enable the installation of targets." ON)
+
 if(MSVC)
   set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 endif()
@@ -113,53 +115,57 @@ set_target_properties(quickflux PROPERTIES
   DEBUG_POSTFIX d
   )
 
-install(TARGETS quickflux EXPORT QuickFluxTargets
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/quickflux"
+if(quickflux_INSTALL)
+
+  install(TARGETS quickflux EXPORT QuickFluxTargets
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/quickflux"
+    )
+
+  install(FILES
+    ${quickflux_PUBLIC_HEADERS}
+    DESTINATION include/quickflux
+    )
+  install(FILES
+    ${quickflux_PRIVATE_HEADERS}
+    DESTINATION include/quickflux/priv
+    )
+
+
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(
+      ${CMAKE_BINARY_DIR}/cmake/QuickFluxVersion.cmake
+      VERSION ${PROJECT_VERSION}
+      COMPATIBILITY SameMajorVersion
   )
 
-install(FILES
-  ${quickflux_PUBLIC_HEADERS}
-  DESTINATION include/quickflux
-  )
-install(FILES
-  ${quickflux_PRIVATE_HEADERS}
-  DESTINATION include/quickflux/priv
+  # installation - build tree specific package config files
+  export(EXPORT QuickFluxTargets FILE ${CMAKE_BINARY_DIR}/QuickFluxTargets.cmake)
+  configure_file(${PROJECT_SOURCE_DIR}/QuickFluxConfig.cmake.in
+      ${CMAKE_BINARY_DIR}/QuickFluxConfig.cmake
+      COPYONLY
   )
 
+  # installation - relocatable package config files
+  configure_package_config_file(${PROJECT_SOURCE_DIR}/QuickFluxConfig.cmake.in
+                                ${CMAKE_CURRENT_BINARY_DIR}/cmake/QuickFluxConfig.cmake
+                                INSTALL_DESTINATION cmake
+  )
 
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    ${CMAKE_BINARY_DIR}/cmake/QuickFluxVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
+  set(CONFIG_PACKAGE_LOCATION ${CMAKE_INSTALL_LIBDIR}/cmake/QuickFlux)
 
-# installation - build tree specific package config files
-export(EXPORT QuickFluxTargets FILE ${CMAKE_BINARY_DIR}/QuickFluxTargets.cmake)
-configure_file(${PROJECT_SOURCE_DIR}/QuickFluxConfig.cmake.in
-    ${CMAKE_BINARY_DIR}/QuickFluxConfig.cmake
-    COPYONLY
-)
+  install(EXPORT QuickFluxTargets
+      FILE QuickFluxTargets.cmake
+      NAMESPACE QuickFlux::
+      DESTINATION ${CONFIG_PACKAGE_LOCATION}
+  )
 
-# installation - relocatable package config files
-configure_package_config_file(${PROJECT_SOURCE_DIR}/QuickFluxConfig.cmake.in
-                              ${CMAKE_CURRENT_BINARY_DIR}/cmake/QuickFluxConfig.cmake
-                              INSTALL_DESTINATION cmake
-)
+  install(FILES
+      ${CMAKE_BINARY_DIR}/cmake/QuickFluxConfig.cmake
+      ${CMAKE_BINARY_DIR}/cmake/QuickFluxVersion.cmake
+      DESTINATION ${CONFIG_PACKAGE_LOCATION}
+  )
 
-set(CONFIG_PACKAGE_LOCATION ${CMAKE_INSTALL_LIBDIR}/cmake/QuickFlux)
-
-install(EXPORT QuickFluxTargets
-    FILE QuickFluxTargets.cmake
-    NAMESPACE QuickFlux::
-    DESTINATION ${CONFIG_PACKAGE_LOCATION}
-)
-
-install(FILES
-    ${CMAKE_BINARY_DIR}/cmake/QuickFluxConfig.cmake
-    ${CMAKE_BINARY_DIR}/cmake/QuickFluxVersion.cmake
-    DESTINATION ${CONFIG_PACKAGE_LOCATION}
-)
+endif()


### PR DESCRIPTION
This allow to disable the installation of quickflux, if using quickflux in a superbuild and linking PRIVATE to quickflux. In that case quickflux doesn't need to be installed along the superbuild target, since it will be compiled into the library binary.

The option is defaulted to ON, so it shouldn't change anything for user using the default options.

Example case:
```cmake
FetchContent_Declare(quickflux
  GIT_REPOSITORY https://github.com/benlau/quickflux
  GIT_TAG        master
)
set(quickflux_INSTALL OFF)
FetchContent_MakeAvailable(quickflux)

add_executable(mytarget ...) 
target_link_libraries(mytarget PRIVATE quickflux)
install(TARGETS mytarget)
```

Let's say `make install` will only install `mytarget.exe`. Otherwise it would also install a `quickflux.lib` that isn't relevant for the user of `mytarget.exe`.

> You might have conflict to solve with my other PR https://github.com/benlau/quickflux/pull/31 since they are writing in the same line of the CMakeLists.txt (my bad), i can rebase on the other PR once one is merged)