### PR TITLE
Don't write to global variable CMAKE_AUTOMOC & CMAKE_DEBUG_POSTFIX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,6 @@ if(MSVC)
   set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 endif()
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_DEBUG_POSTFIX d)
-
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")
 
 include(GNUInstallDirs)
@@ -110,6 +106,11 @@ target_include_directories(quickflux
   PUBLIC
   "$<BUILD_INTERFACE:${SRC_DIR}>"
   "$<INSTALL_INTERFACE:include/quickflux>"
+  )
+
+set_target_properties(quickflux PROPERTIES
+  AUTOMOC TRUE
+  DEBUG_POSTFIX d
   )
 
 install(TARGETS quickflux EXPORT QuickFluxTargets


### PR DESCRIPTION
Writing to global variable isn't a good thing with cmake, for people like me doing superbuild.

```cmake
FetchContent_Declare(quickflux
  GIT_REPOSITORY https://github.com/benlau/quickflux
  GIT_TAG        master
)
FetchContent_MakeAvailable(quickflux)

add_executable(mytarget ...) 
```

When i'm doing `cmake --build . --target mytarget --config "Debug"` i want my output binary to be mytarget.exe by default. I don't want quick flux to have impact on that. This is why `CMAKE_DEBUG_POSTFIX` should only be set to target `quickflux`.

Same thing for `CMAKE_AUTOMOC`, i don't want all my targets in my superbuild to be moced since lot of library don't use qt.

> You might have conflict to solve with my other PR https://github.com/benlau/quickflux/pull/30 since they are writing in the same line of the CMakeLists.txt (my bad), i can rebase on the other PR once one is merged)