### PR TITLE
Qt 5.14+ deprecation fixes.

### DIFF
--- a/src/qffilter.cpp
+++ b/src/qffilter.cpp
@@ -177,6 +177,11 @@ void QFFilter::setTypes(const QStringList &types)
 
 QQmlListProperty<QObject> QFFilter::children()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this),
+                                     &m_children);
+#else
     return QQmlListProperty<QObject>(qobject_cast<QObject*>(this),
                                      m_children);
+#endif
 }

--- a/src/qfobject.cpp
+++ b/src/qfobject.cpp
@@ -7,5 +7,11 @@ QFObject::QFObject(QObject *parent) : QObject(parent)
 
 QQmlListProperty<QObject> QFObject::children()
 {
-    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_children);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this),
+                                     &m_children);
+#else
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this),
+                                     m_children);
+#endif
 }

--- a/src/qfqmltypes.cpp
+++ b/src/qfqmltypes.cpp
@@ -50,7 +50,11 @@ void registerQuickFluxQmlTypes()
     qmlRegisterType<QFAppScript>("QuickFlux", 1, 0, "AppScript");
     qmlRegisterType<QFAppListenerGroup>("QuickFlux", 1, 0, "AppListenerGroup");
     qmlRegisterType<QFAppScriptGroup>("QuickFlux", 1, 0, "AppScriptGroup");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    qmlRegisterAnonymousType<QFAppScriptRunnable>("QuickFlux", 1);
+#else
     qmlRegisterType<QFAppScriptRunnable>();
+#endif
     qmlRegisterType<QFKeyTable>("QuickFlux", 1, 0, "KeyTable");
     qmlRegisterType<QFActionCreator>("QuickFlux", 1, 0, "ActionCreator");
     qmlRegisterType<QFFilter>("QuickFlux", 1, 0, "Filter");

--- a/src/qfstore.cpp
+++ b/src/qfstore.cpp
@@ -125,7 +125,13 @@ QFStore::QFStore(QObject *parent) : QObject(parent) , m_filterFunctionEnabled(fa
 
 QQmlListProperty<QObject> QFStore::children()
 {
-    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_children);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this),
+                                     &m_children);
+#else
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this),
+                                     m_children);
+#endif
 }
 
 void QFStore::dispatch(QString type, QJSValue message)
@@ -245,7 +251,13 @@ void QFStore::setup()
 
 QQmlListProperty<QObject> QFStore::redispatchTargets()
 {
-    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_redispatchTargets);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this),
+                                     &m_redispatchTargets);
+#else
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this),
+                                     m_redispatchTargets);
+#endif
 }
 
 


### PR DESCRIPTION
There were two types of deprecation warnings during compile. It was not possible to compile with -Werror. (Tested with Qt 5.15.1)